### PR TITLE
Fix wrong player controller used when executing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Powered by UE4SS lua scripts!
 
 Most of the settings can be configured using environment variables:
 
-| Variable name          | Default value | Description                                                          |
-| ---------------------- | ------------- | -------------------------------------------------------------------- |
-| `MOD_LUA_PORT`         | `5001`        | Lua HTTP port. This only applies if `luasocket` module is installed  |
-| `MOD_WEBHOOK_URL`      | _none_        | Webhook URL to send the events to. Requires `luasec` to function     |
-| `MOD_AUTO_FPS_ENABLE`  | _none_        | Enable automatic server traffic adjustment based on the server's FPS |
+| Variable name         | Default value | Description                                                          |
+| --------------------- | ------------- | -------------------------------------------------------------------- |
+| `MOD_LUA_PORT`        | `5001`        | Lua HTTP port. This only applies if `luasocket` module is installed  |
+| `MOD_WEBHOOK_URL`     | _none_        | Webhook URL to send the events to. Requires `luasec` to function     |
+| `MOD_SERVER_API_URL`  | _none_        | Server API to call from client side                                  |
+| `MOD_AUTO_FPS_ENABLE` | _none_        | Enable automatic server traffic adjustment based on the server's FPS |
 
 ## Documentation
 

--- a/Scripts/Helpers.lua
+++ b/Scripts/Helpers.lua
@@ -4,25 +4,24 @@ local myPlayerControllerCache = CreateInvalidObject() ---@cast myPlayerControlle
 ---Get my own PlayerController
 ---@return APlayerController
 function GetMyPlayerController()
-    if myPlayerControllerCache:IsValid() then
-        return myPlayerControllerCache
-    end
-
-    local gameInstance = UEHelpers.GetGameInstance()
-    if gameInstance:IsValid() and gameInstance.LocalPlayers and #gameInstance.LocalPlayers > 0 then
-        local localPlayer = gameInstance.LocalPlayers[1]
-        if localPlayer:IsValid() then
-            myPlayerControllerCache = localPlayer.PlayerController
-        end
-    else
-        local playerController = UEHelpers.GetPlayerController()
-        if playerController:IsValid() then
-            myPlayerControllerCache = playerController
-        end
-    end
+  if myPlayerControllerCache:IsValid() then
     return myPlayerControllerCache
-end
+  end
 
+  local gameInstance = UEHelpers.GetGameInstance()
+  if gameInstance:IsValid() and gameInstance.LocalPlayers and #gameInstance.LocalPlayers > 0 then
+    local localPlayer = gameInstance.LocalPlayers[1]
+    if localPlayer:IsValid() then
+      myPlayerControllerCache = localPlayer.PlayerController
+    end
+  else
+    local playerController = UEHelpers.GetPlayerController()
+    if playerController:IsValid() then
+      myPlayerControllerCache = playerController
+    end
+  end
+  return myPlayerControllerCache
+end
 
 -- Importing functions to the global namespace of this mod just so that we don't have to retype 'UEHelpers.' over and over again.
 local GetKismetSystemLibrary = UEHelpers.GetKismetSystemLibrary

--- a/Scripts/Helpers.lua
+++ b/Scripts/Helpers.lua
@@ -1,9 +1,32 @@
 local UEHelpers = require("UEHelpers")
 
+local myPlayerControllerCache = CreateInvalidObject() ---@cast myPlayerControllerCache APlayerController
+---Get my own PlayerController
+---@return APlayerController
+function GetMyPlayerController()
+    if myPlayerControllerCache:IsValid() then
+        return myPlayerControllerCache
+    end
+
+    local gameInstance = UEHelpers.GetGameInstance()
+    if gameInstance:IsValid() and gameInstance.LocalPlayers and #gameInstance.LocalPlayers > 0 then
+        local localPlayer = gameInstance.LocalPlayers[1]
+        if localPlayer:IsValid() then
+            myPlayerControllerCache = localPlayer.PlayerController
+        end
+    else
+        local playerController = UEHelpers.GetPlayerController()
+        if playerController:IsValid() then
+            myPlayerControllerCache = playerController
+        end
+    end
+    return myPlayerControllerCache
+end
+
+
 -- Importing functions to the global namespace of this mod just so that we don't have to retype 'UEHelpers.' over and over again.
 local GetKismetSystemLibrary = UEHelpers.GetKismetSystemLibrary
 local GetKismetMathLibrary = UEHelpers.GetKismetMathLibrary
-local GetPlayerController = UEHelpers.GetPlayerController
 
 local IsInitialized = false
 
@@ -40,7 +63,7 @@ end
 local function GetObjectFromLineTrace()
   if not IsInitialized then return selectedActor end
 
-  local PlayerController = GetPlayerController()
+  local PlayerController = GetMyPlayerController()
   local PlayerPawn = PlayerController.Pawn
   local CameraManager = PlayerController.PlayerCameraManager
   local StartVector = CameraManager:GetCameraLocation()

--- a/Scripts/VehicleManager.lua
+++ b/Scripts/VehicleManager.lua
@@ -1075,7 +1075,10 @@ local function VehicleToTable(vehicle)
   -- data.RootBody = vehicle.RootBody
   -- data.Mesh = vehicle.Mesh
   -- data.SteeringWheel = vehicle.SteeringWheel
-  -- data.Wheels = vehicle.Wheels
+  data.Wheels = {}
+  vehicle.Wheels:ForEach(function(index, element)
+    table.insert(data.Wheels, WheelCompToTable(element:get()))
+  end)
   -- data.EngineComponent = vehicle.EngineComponent
   -- data.CargoSpaceInteractableComponent = vehicle.CargoSpaceInteractableComponent
   -- data.DrivingInput = vehicle.DrivingInput
@@ -1505,30 +1508,30 @@ end)
 
 RegisterConsoleCommandHandler("setvehicleparam", function(Cmd, CommandParts, Ar)
   if not pcall(function()
-    local fields = SplitString(table.remove(CommandParts, 1), ".")
-    local value = CommandParts[1]
+        local fields = SplitString(table.remove(CommandParts, 1), ".")
+        local value = CommandParts[1]
 
-    if not fields then
-      LogMsg("No fields value given.", "ERROR")
-      return true
-    end
+        if not fields then
+          LogMsg("No fields value given.", "ERROR")
+          return true
+        end
 
-    if value == nil then
-      LogMsg("No valid value given.", "ERROR")
-      return true
-    end
+        if value == nil then
+          LogMsg("No valid value given.", "ERROR")
+          return true
+        end
 
-    local PC = GetMyPlayerController()
-    if PC:IsValid() then
-      local pawn = PC:K2_GetPawn()
-      local vehicleClass = StaticFindObject("/Script/MotorTown.MTVehicle")
-      ---@cast vehicleClass UClass
+        local PC = GetMyPlayerController()
+        if PC:IsValid() then
+          local pawn = PC:K2_GetPawn()
+          local vehicleClass = StaticFindObject("/Script/MotorTown.MTVehicle")
+          ---@cast vehicleClass UClass
 
-      if pawn:IsValid() and pawn:IsA(vehicleClass) then
-        RecursiveSetValue(pawn, fields, value)
-      end
-    end
-  end) then
+          if pawn:IsValid() and pawn:IsA(vehicleClass) then
+            RecursiveSetValue(pawn, fields, value)
+          end
+        end
+      end) then
     LogMsg("Failed to change " .. CommandParts[2] .. " field for pawn")
   end
 

--- a/Scripts/VehicleManager.lua
+++ b/Scripts/VehicleManager.lua
@@ -1496,7 +1496,7 @@ RegisterConsoleCommandHandler("despawnvehicle", function()
     ---@cast actor AMTVehicle
 
     local vehicleName = actor:GetFullName()
-    if DespawnVehicleById(actor.Net_VehicleId, GetPlayerGuid(UEHelpers.GetPlayerController())) then
+    if DespawnVehicleById(actor.Net_VehicleId, GetPlayerGuid(GetMyPlayerController())) then
       LogMsg("Despawned vehicle: " .. vehicleName)
     end
   end
@@ -1504,28 +1504,32 @@ RegisterConsoleCommandHandler("despawnvehicle", function()
 end)
 
 RegisterConsoleCommandHandler("setvehicleparam", function(Cmd, CommandParts, Ar)
-  local fields = SplitString(table.remove(CommandParts, 1), ".")
-  local value = CommandParts[1]
+  if not pcall(function()
+    local fields = SplitString(table.remove(CommandParts, 1), ".")
+    local value = CommandParts[1]
 
-  if not fields then
-    LogMsg("No fields value given.", "ERROR")
-    return true
-  end
-
-  if value == nil then
-    LogMsg("No valid value given.", "ERROR")
-    return true
-  end
-
-  local PC = UEHelpers:GetPlayerController()
-  if PC:IsValid() then
-    local pawn = PC:K2_GetPawn()
-    local vehicleClass = StaticFindObject("/Script/MotorTown.MTVehicle")
-    ---@cast vehicleClass UClass
-
-    if pawn:IsValid() and pawn:IsA(vehicleClass) then
-      RecursiveSetValue(pawn, fields, value)
+    if not fields then
+      LogMsg("No fields value given.", "ERROR")
+      return true
     end
+
+    if value == nil then
+      LogMsg("No valid value given.", "ERROR")
+      return true
+    end
+
+    local PC = GetMyPlayerController()
+    if PC:IsValid() then
+      local pawn = PC:K2_GetPawn()
+      local vehicleClass = StaticFindObject("/Script/MotorTown.MTVehicle")
+      ---@cast vehicleClass UClass
+
+      if pawn:IsValid() and pawn:IsA(vehicleClass) then
+        RecursiveSetValue(pawn, fields, value)
+      end
+    end
+  end) then
+    LogMsg("Failed to change " .. CommandParts[2] .. " field for pawn")
   end
 
   return true


### PR DESCRIPTION
Fix invalid memory access due to an invalid player controller being used to execute commands. Also added the missing `MOD_SERVER_API_URL` environment variable in the documentation. This variable is used to delegate client-to-server commands.