### PR TITLE
Add stop webserver command and request

### DIFF
--- a/Scripts/main.lua
+++ b/Scripts/main.lua
@@ -81,8 +81,7 @@ local function LoadWebserver()
     Webserver.registerHandler("/assets/spawn", "POST", assetManager.HandleSpawnActor)
     Webserver.registerHandler("/assets/despawn", "POST", assetManager.HandleDespawnActor)
 
-    local port = os.getenv("MOD_LUA_PORT") or "5001"
-    Webserver.run("*", tonumber(port))
+    Webserver.run("*")
     return nil
   end)
   if not status then

--- a/docs/ConsoleCommands.md
+++ b/docs/ConsoleCommands.md
@@ -4,6 +4,7 @@ List of Motor Town console commands.
 
 ## General
 
+* `stopwebserver` - Stop the webserver. Useful for restarting Lua mods.
 * `setnpctraffic <amount>` - Set the current traffic amount. Defaults to `1.0`.
 
 ## Player management

--- a/docs/LuaHttpServer.md
+++ b/docs/LuaHttpServer.md
@@ -4,6 +4,19 @@
 
 Query parameter and/or request body is not needed unless specified. A basic HTTP authentication header `Authorization: Basic <token>` is required for all request unless specified otherwise. The `token` can be either hashed with `bcrypt` or a simple `base64` encoding.
 
+### Webserver control
+
+#### POST `/stop`
+
+Stop the webserver. Useful for restarting the Lua mods. Note that it will still try to complete any ongoing request before stopping. Future request will be rejected.
+
+<details>
+<summary>Response data:</summary>
+
+Returns `200 OK` for successful stop command. Will output `Webserver stopped` in the log to confirm the full webserver shutdown.
+
+</details>
+
 ### General server settings
 
 #### GET `/status`


### PR DESCRIPTION
A new `stopwebserver` command is added to stop the webserver thread. It will try to complete any ongoing request before shutting down the server.