### PR TITLE
Build Lua deps

### DIFF
--- a/.github/workflows/msvc_build.yml
+++ b/.github/workflows/msvc_build.yml
@@ -1,7 +1,9 @@
 name: Build release
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - main
     paths:
@@ -11,22 +13,27 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
-  make-release:
-    permissions: write-all
+  build-core:
     runs-on: windows-2022
+    if: github.event.pull_request.merged == true
+    outputs:
+      version: ${{ steps.package-build.outputs.version }}
+      majorMinorVersion: ${{ steps.package-build.outputs.majorMinorVersion }}
 
     steps:
       - name: Checkout working repository
         uses: actions/checkout@v4
         with:
           path: MotorTownMods
+          fetch-depth: 0 # Allows diff to work
 
       - name: Check for src changes
         id: check-src-changes
         run: |
-          git -C MotorTownMods diff --quiet ${{ github.event.before }} ${{ github.sha }} -- src/ || echo "src_changed=true" >> $GITHUB_OUTPUT
+          git -C MotorTownMods diff --quiet ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- src/ || echo "src_changed=true" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Download previous main.dll if src not changed
@@ -104,31 +111,110 @@ jobs:
         with:
           name: MotorTownMods_main_dll
           path: Binaries/Game__Shipping__Win64/MotorTownMods/MotorTownMods.dll
+          overwrite: true
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
-        continue-on-error: true
         with:
           name: MotorTownMods_release
           path: |
+            MotorTownMods_v*.zip
             release_description.md
-            commit_msg.txt
-          if-no-files-found: warn
           overwrite: true
+
+  build-deps:
+    runs-on: windows-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: MotorTownMods_lua_deps
+
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: hashFiles('shared.zip') == '' || contains(github.event.pull_request.labels.*.name, 'build-deps')
+
+      - uses: ilammy/setup-nasm@v1
+        if: hashFiles('shared.zip') == '' || contains(github.event.pull_request.labels.*.name, 'build-deps')
+
+      - uses: luarocks/gh-actions-lua@v11
+        if: hashFiles('shared.zip') == '' || contains(github.event.pull_request.labels.*.name, 'build-deps')
+
+      - uses: luarocks/gh-actions-luarocks@v6
+        if: hashFiles('shared.zip') == '' || contains(github.event.pull_request.labels.*.name, 'build-deps')
+
+      - uses: shogo82148/actions-setup-perl@v1
+        if: hashFiles('shared.zip') == '' || contains(github.event.pull_request.labels.*.name, 'build-deps')
+        with:
+          perl-version: "5.32"
+          distribution: strawberry
+
+      - name: Checkout OpenSSL
+        uses: actions/checkout@v4
+        if: hashFiles('shared.zip') == '' || contains(github.event.pull_request.labels.*.name, 'build-deps')
+        with:
+          repository: openssl/openssl
+          path: OpenSSL
+          ref: openssl-3.0
+
+      - name: Build OpenSSL
+        if: hashFiles('shared.zip') == '' || contains(github.event.pull_request.labels.*.name, 'build-deps')
+        run: |
+          cd OpenSSL
+          perl Configure VC-WIN64A
+          nmake
+
+      - name: install modules
+        if: hashFiles('shared.zip') == '' || contains(github.event.pull_request.labels.*.name, 'build-deps')
+        run: |
+          luarocks install --local luasocket
+          luarocks install --local luasec OPENSSL_DIR=${{ github.workspace }}\OpenSSL
+          luarocks install --local bcrypt
+
+      - name: Package modules
+        if: hashFiles('shared.zip') == '' || contains(github.event.pull_request.labels.*.name, 'build-deps')
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory shared
+          Copy-Item -Recurse -Force $env:APPDATA\luarocks\lib\lua\5.4\* .\shared\
+          Copy-Item -Recurse -Force $env:APPDATA\luarocks\share\lua\5.4\* .\shared\
+          Compress-Archive -Path .\shared ".\shared.zip"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: hashFiles('shared.zip') == '' || contains(github.event.pull_request.labels.*.name, 'build-deps')
+        with:
+          name: MotorTownMods_lua_deps
+          path: shared.zip
+          overwrite: true
+
+  create-release:
+    if: github.event.pull_request.merged == true
+    needs:
+      - build-core
+      - build-deps
+    permissions: write-all
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: MotorTownMods_release,MotorTownMods_lua_deps
 
       - name: Delete old release assets
         uses: mknejp/delete-release-assets@v1
         continue-on-error: true
         with:
           token: ${{ github.token }}
-          tag: v${{ steps.package-build.outputs.majorMinorVersion }}
+          tag: v${{ needs.build-core.outputs.majorMinorVersion }}
           assets: "*"
 
       - name: Create/update release
         uses: softprops/action-gh-release@v2
         with:
-          name: MotorTownMods v${{ steps.package-build.outputs.version }}
-          tag_name: v${{ steps.package-build.outputs.majorMinorVersion }}
+          name: MotorTownMods v${{ needs.build-core.outputs.version }}
+          tag_name: v${{ needs.build-core.outputs.majorMinorVersion }}
           body_path: release_description.md
-          files: MotorTownMods_v*.zip
+          files: "*.zip"
           make_latest: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Motor Town Mods
 
-Powered by UE4SS lua scripts!
+Powered by UE4SS lua scripts! This mod focuses primarily towards dedicated server. Some commands work on client-side, though results may vary depending on the game's replication system.
 
 ## Usage
 

--- a/Scripts/Statics.lua
+++ b/Scripts/Statics.lua
@@ -1,5 +1,5 @@
 return {
     ModName = "MotorTownMods",
-    ModVersion = "0.5.4",
+    ModVersion = "0.5.5",
     ModLogLevel = 2,
 }


### PR DESCRIPTION
Include all Lua dependencies in each releases. This should reduce the amount of headache when trying to build obscure Lua modules.