### PR TITLE
Handle malformed requests

### DIFF
--- a/Scripts/CargoManager.lua
+++ b/Scripts/CargoManager.lua
@@ -379,6 +379,9 @@ local function GetDeliveryPoints(guid, fields, limit)
       end
     end
   end
+  if guid and #arr == 0 then
+    error("Delivery point with guid " .. guid .. " does not exist")
+  end
   return arr
 end
 
@@ -403,8 +406,12 @@ RegisterHook(
 ---Handle GetDeliveryPoints request
 ---@type RequestPathHandler
 local function HandleGetDeliveryPoints(session)
-  local guid = session.urlComponents[3] or nil
-  local limit = session.queryComponents.limit and tonumber(session.queryComponents.limit) or nil
+  local guid = session.pathComponents[3]
+  local limit = nil ---@type number?
+
+  if session.queryComponents.limit then
+    limit = tonumber(session.queryComponents.limit)
+  end
 
   local rawFilters = session.queryComponents.filters
   local filters = SplitString(rawFilters, ",")

--- a/Scripts/EventManager.lua
+++ b/Scripts/EventManager.lua
@@ -105,9 +105,6 @@ local function GetEvents(eventGuid)
 
     ::continue::
   end)
-  if eventGuid and #arr == 0 then
-    error("Event with guid " .. eventGuid .. " not found")
-  end
   return arr
 end
 
@@ -430,21 +427,13 @@ RegisterHook(
 
 ---Handle request for all events
 ---@type RequestPathHandler
-local function HandleGetAllEvents(session)
-  local events = json.stringify {
-    data = GetEvents()
-  }
-  return events
-end
-
----Handle request for all events
----@type RequestPathHandler
-local function HandleGetSpecificEvents(session)
+local function HandleGetEvents(session)
   local eventGuid = session.pathComponents[2]
-  local events = json.stringify {
-    data = GetEvents(eventGuid)
-  }
-  return events
+  local res = GetEvents(eventGuid)
+  if eventGuid and #res == 0 then
+    return json.stringify { message = string.format("Event %s not found", eventGuid) }, nil, 404
+  end
+  return json.stringify { data = res }, nil, 200
 end
 
 ---Handle request for a new event
@@ -525,8 +514,7 @@ end
 
 return {
   GetEvents = GetEvents,
-  HandleGetAllEvents = HandleGetAllEvents,
-  HandleGetSpecificEvents = HandleGetSpecificEvents,
+  HandleGetEvents = HandleGetEvents,
   HandleUpdateEvent = HandleUpdateEvent,
   HandleCreateNewEvent = HandleCreateNewEvent,
   HandleChangeEventState = HandleChangeEventState,

--- a/Scripts/EventManager.lua
+++ b/Scripts/EventManager.lua
@@ -105,6 +105,9 @@ local function GetEvents(eventGuid)
 
     ::continue::
   end)
+  if eventGuid and #arr == 0 then
+    error("Event with guid " .. eventGuid .. " not found")
+  end
   return arr
 end
 

--- a/Scripts/Helpers.lua
+++ b/Scripts/Helpers.lua
@@ -320,10 +320,11 @@ function GameplayTagQueryToTable(query)
   return data
 end
 
----Split string
----@param inputstr string
----@param sep string?
----@return string[]|nil
+---Split string by the separator.
+---Returns `nil` if input is `nil` or empty.
+---@param inputstr string Input string
+---@param sep string? Separator character(s). Defaults to a whitespace.
+---@return string[]?
 function SplitString(inputstr, sep)
   if inputstr == nil then return nil end
   -- if sep is null, set it as space

--- a/Scripts/PlayerManager.lua
+++ b/Scripts/PlayerManager.lua
@@ -57,6 +57,9 @@ local function GetPlayerStates(guid)
 
     ::continue::
   end)
+  if guid and #arr == 0 then
+    error("Player with guid " .. guid .. " not found")
+  end
   return arr
 end
 

--- a/Scripts/PlayerManager.lua
+++ b/Scripts/PlayerManager.lua
@@ -57,9 +57,6 @@ local function GetPlayerStates(guid)
 
     ::continue::
   end)
-  if guid and #arr == 0 then
-    error("Player with guid " .. guid .. " not found")
-  end
   return arr
 end
 
@@ -98,24 +95,16 @@ end)
 ---Handle request for player states
 ---@param session ClientTable
 local function HandleGetPlayerStates(session)
-  local playerStates = json.stringify {
-    data = GetPlayerStates()
-  }
-  return playerStates
-end
-
----Handle request for player states
----@param session ClientTable
-local function HandleGetSpecifcPlayerStates(session)
   local playerGuid = session.pathComponents[2]
-  local playerStates = json.stringify {
-    data = GetPlayerStates(playerGuid)
-  }
-  return playerStates
+  local res = GetPlayerStates(playerGuid)
+  if playerGuid and #res == 0 then
+    return json.stringify { message = string.format("Player with guid %s not found", playerGuid) }, nil, 404
+  end
+
+  return json.stringify { data = res }, nil, 200
 end
 
 return {
   HandleGetPlayerStates = HandleGetPlayerStates,
-  HandleGetSpecifcPlayerStates = HandleGetSpecifcPlayerStates,
   GetMyCurrentTransform = GetMyCurrentTransform
 }

--- a/Scripts/Statics.lua
+++ b/Scripts/Statics.lua
@@ -1,5 +1,5 @@
 return {
     ModName = "MotorTownMods",
-    ModVersion = "0.6.3",
+    ModVersion = "0.6.4",
     ModLogLevel = 2,
 }

--- a/Scripts/VehicleManager.lua
+++ b/Scripts/VehicleManager.lua
@@ -1442,6 +1442,9 @@ local function GetVehicles(id, fields, limit)
     end
   end
 
+  if id and #arr == 0 then
+    error("Vehicle with id " .. id .. " not found")
+  end
   return arr
 end
 
@@ -1620,12 +1623,16 @@ end)
 local function HandleGetVehicles(session)
   local id = tonumber(session.pathComponents[2]) or nil
   local fields = SplitString(session.queryComponents.filters, ",")
-  local limit = session.queryComponents.limit and tonumber(session.queryComponents.limit) or nil
+  local limit = nil ---@type number?
+
+  if session.queryComponents.limit then
+    limit = tonumber(session.queryComponents.limit)
+  end
 
   local serverStatus = json.stringify {
     data = GetVehicles(id, fields, limit)
   }
-  return serverStatus
+  return serverStatus, nil, 200
 end
 
 ---Handle vehicle despawn request

--- a/Scripts/Webserver.lua
+++ b/Scripts/Webserver.lua
@@ -92,6 +92,7 @@ function ClientTable.new(newId, client)
     obj.client = client
     obj.state = "init"
     obj.connTime = time()
+    obj.queryComponents = {}
     return obj
 end
 
@@ -431,6 +432,7 @@ end
 
 ---Turns a query string into a table of name/value pairs
 ---@param path string
+---@return table<string, string>
 local function decodeQuery(path)
     local cgi = {}
     for name, value in string.gmatch(path, "([^&=]+)=([^&=]+)") do

--- a/Scripts/Webserver.lua
+++ b/Scripts/Webserver.lua
@@ -446,78 +446,86 @@ end
 local function handleClient(client)
     local s = sessions[client]
 
-    local data, err, partial
+    local data = nil ---@type string?
+    local err = nil ---@type string|"closed"|"timeout"|nil
+    local partial = nil ---@type number?
 
-    if s.state == "init" or s.state == "header" then
-        data, err, partial = client:receive("*l")
-    elseif s.state == "body" then
-        data, err, partial = client:receive(s.contentLength)
-    end
+    local state, pErr = pcall(function()
+        if s.state == "init" or s.state == "header" then
+            data, err, partial = client:receive("*l")
+        elseif s.state == "body" then
+            data, err, partial = client:receive(s.contentLength)
+        end
 
-    if data then
-        if s.state == "init" then
-            LogOutput("DEBUG", "(%d) INIT: '%s'", s.id, data)
-            s.rawHeaders = {}
-            local method, urlString, ver = string.match(data, "(%S+)%s+(%S+)%s+(%S+)")
-            if method ~= nil then
-                s.method = method
-                s.urlString = urlString
+        if data then
+            if s.state == "init" then
+                LogOutput("DEBUG", "(%d) INIT: '%s'", s.id, data)
+                s.rawHeaders = {}
+                local method, urlString, ver = string.match(data, "(%S+)%s+(%S+)%s+(%S+)")
+                if method ~= nil then
+                    s.method = method
+                    s.urlString = urlString
 
-                -- Break down the url string
-                s.urlComponents = url.parse(urlString)
+                    -- Break down the url string
+                    s.urlComponents = url.parse(urlString)
 
-                s.pathComponents = url.parse_path(s.urlComponents.path)
+                    s.pathComponents = url.parse_path(s.urlComponents.path)
 
-                LogOutput("DEBUG", "Query Components %s", s.urlComponents.query or "")
-                if s.urlComponents.query ~= nil then
-                    s.queryComponents = decodeQuery(s.urlComponents.query)
-                end
+                    LogOutput("DEBUG", "Query Components %s", s.urlComponents.query or "")
+                    if s.urlComponents.query ~= nil then
+                        s.queryComponents = decodeQuery(s.urlComponents.query)
+                    end
 
-                s.version = ver
+                    s.version = ver
 
-                s.state = "header"
-            else
-                LogOutput("ERROR", "Malformed initial line")
-                sendResponse(s, nil, nil, 400)
-            end
-        elseif s.state == "header" then
-            LogOutput("DEBUG", "(%d)  HDR: %s", s.id, data)
-            if data ~= "" then
-                table.insert(s.rawHeaders, data)
-            else
-                LogOutput("DEBUG", "(%d)  End Headers", s.id)
-                local rc = parseHeaders(s)
-                if rc ~= 0 then
-                    sendResponse(s, nil, nil, 400)
-                    return
-                end
-
-                processHeaders(s)
-
-                if s.contentLength == 0 then
-                    LogOutput("DEBUG", "Content length = 0, not waiting for content")
-                    -- Processing the session will result in it being closed
-                    processSession(s)
+                    s.state = "header"
                 else
-                    LogOutput("DEBUG", "Waiting for content")
-                    s.state = "body"
+                    LogOutput("ERROR", "Malformed initial line")
+                    sendResponse(s, nil, nil, 400)
                 end
+            elseif s.state == "header" then
+                LogOutput("DEBUG", "(%d)  HDR: %s", s.id, data)
+                if data ~= "" then
+                    table.insert(s.rawHeaders, data)
+                else
+                    LogOutput("DEBUG", "(%d)  End Headers", s.id)
+                    local rc = parseHeaders(s)
+                    if rc ~= 0 then
+                        sendResponse(s, nil, nil, 400)
+                        return
+                    end
+
+                    processHeaders(s)
+
+                    if s.contentLength == 0 then
+                        LogOutput("DEBUG", "Content length = 0, not waiting for content")
+                        -- Processing the session will result in it being closed
+                        processSession(s)
+                    else
+                        LogOutput("DEBUG", "Waiting for content")
+                        s.state = "body"
+                    end
+                end
+            else
+                s.content = data
+                processSession(s)
             end
         else
-            s.content = data
-            processSession(s)
+            if err == "closed" then
+                LogOutput("DEBUG", "Client closed the connection: ")
+                markSessionForRemoval(s)
+            elseif err == "timeout" then
+                LogOutput("ERROR", "Receive timeout. Partial data: %s", partial)
+                markSessionForRemoval(s)
+            else
+                LogOutput("ERROR", "Receive error: %s", err)
+                markSessionForRemoval(s)
+            end
         end
-    else
-        if err == "closed" then
-            LogOutput("DEBUG", "Client closed the connection: ")
-            markSessionForRemoval(s)
-        elseif err == "timeout" then
-            LogOutput("ERROR", "Receive timeout. Partial data: %s", partial)
-            markSessionForRemoval(s)
-        else
-            LogOutput("ERROR", "Receive error: %s", err)
-            markSessionForRemoval(s)
-        end
+    end)
+    if not state then
+        LogOutput("ERROR", "Process error: %s", pErr)
+        markSessionForRemoval(s)
     end
 end
 

--- a/Scripts/main.lua
+++ b/Scripts/main.lua
@@ -70,12 +70,12 @@ local function LoadWebserver()
 
     -- Player management
     Webserver.registerHandler("/players", "GET", playerManager.HandleGetPlayerStates)
-    Webserver.registerHandler("/players/*", "GET", playerManager.HandleGetSpecifcPlayerStates)
+    Webserver.registerHandler("/players/*", "GET", playerManager.HandleGetPlayerStates)
 
     -- Event management
-    Webserver.registerHandler("/events", "GET", eventManager.HandleGetAllEvents)
+    Webserver.registerHandler("/events", "GET", eventManager.HandleGetEvents)
     Webserver.registerHandler("/events", "POST", eventManager.HandleCreateNewEvent)
-    Webserver.registerHandler("/events/*", "GET", eventManager.HandleGetSpecificEvents)
+    Webserver.registerHandler("/events/*", "GET", eventManager.HandleGetEvents)
     Webserver.registerHandler("/events/*/state", "POST", eventManager.HandleChangeEventState)
     Webserver.registerHandler("/events/*", "POST", eventManager.HandleUpdateEvent)
     Webserver.registerHandler("/events/*", "DELETE", eventManager.HandleRemoveEvent)


### PR DESCRIPTION
* Fix #34 by dropping malformed requests.
* Fix `GET /vehicle/<guid>` and other requests that might return all/empty array. The affected requests now will return 404 instead of empty/all obj.