### PR TITLE
Gracefully handle LogOutput error

### DIFF
--- a/Scripts/ServerManager.lua
+++ b/Scripts/ServerManager.lua
@@ -102,7 +102,7 @@ local npcAmount = 100
 ---@param amount number New density in %
 local function AdjustTrafficDensity(amount)
     if amount ~= npcAmount then
-        LogOutput("INFO", "Changing traffic amount from %.1f% to %.1f%", npcAmount, amount)
+        LogOutput("INFO", "Changing traffic amount from %.1f%% to %.1f%%", npcAmount, amount)
         npcAmount = amount
     end
     local gameState = GetMotorTownGameState()
@@ -149,14 +149,20 @@ local function AutoAdjustServerCaps(override)
     end
 
     if (currentFps <= 0) then
+        LogOutput("DEBUG", "Invalid FPS, not changing anything")
         return false
     elseif (currentFps < 30) then
-        gameState.Net_ServerConfig.MaxVehiclePerPlayer = math.floor(maxVehiclePerPlayer / 2)
+        local newLimit = math.floor(maxVehiclePerPlayer / 2)
+        LogOutput("DEBUG", "Server FPS lower than 30 FPS, setting maxVehiclePerPlayer to %i", newLimit)
+        gameState.Net_ServerConfig.MaxVehiclePerPlayer = newLimit
         AdjustTrafficDensity(0)
     elseif (currentFps < 40) then
-        gameState.Net_ServerConfig.MaxVehiclePerPlayer = math.floor(maxVehiclePerPlayer * 0.75)
+        local newLimit = math.floor(maxVehiclePerPlayer / 0.75)
+        LogOutput("DEBUG", "Server FPS lower than 40 FPS, setting maxVehiclePerPlayer to %i", newLimit)
+        gameState.Net_ServerConfig.MaxVehiclePerPlayer = newLimit
         AdjustTrafficDensity(math.floor(npcVehicleDensity / 2))
     else
+        LogOutput("DEBUG", "Server FPS at 60 FPS or in override mode, setting maxVehiclePerPlayer to %i", maxVehiclePerPlayer)
         gameState.Net_ServerConfig.MaxVehiclePerPlayer = maxVehiclePerPlayer
         AdjustTrafficDensity(npcVehicleDensity)
     end
@@ -223,7 +229,7 @@ local function HandleUpdateNpcTraffic(session)
             maxVehiclePerPlayer = maxV
         end
         AutoAdjustServerCaps(true)
-        return '{"status":"ok"}'
+        return json.stringify { status = "ok" }
     end
     return nil, nil, 400
 end

--- a/Scripts/Statics.lua
+++ b/Scripts/Statics.lua
@@ -1,5 +1,5 @@
 return {
     ModName = "MotorTownMods",
-    ModVersion = "0.6.5",
+    ModVersion = "0.6.6",
     ModLogLevel = 2,
 }

--- a/Scripts/Webserver.lua
+++ b/Scripts/Webserver.lua
@@ -592,16 +592,16 @@ end
 
 ---Initialize the web server
 ---@param host string Host to bind to
----@param port number Port to bind to
-local function init(host, port)
-    g_server = socket.bind(host, port)
+---@param initPort number Port to bind to
+local function init(host, initPort)
+    g_server = socket.bind(host, initPort)
     if g_server == nil then
-        LogOutput("ERROR", "Unable to bind to port %s", port);
+        LogOutput("ERROR", "Unable to bind to port %s", initPort);
         return
     end
 
     local bindAddr, bindPort = g_server:getsockname()
-    LogOutput("INFO", "Webserver listening to host %s on port %i", (bindAddr or host), (bindPort or port))
+    LogOutput("INFO", "Webserver listening to host %s on port %i", (bindAddr or host), (bindPort or initPort))
 
     g_server:settimeout(0.05)
 
@@ -629,7 +629,7 @@ local function run(bindHost, bindPort)
         -- Register core webserver command
         registerHandler("/stop", "POST", function(session)
             isServerRunning = false
-            return '{"status":"ok"}'
+            return json.stringify { status = "ok" }
         end)
 
         init(bindHost, bindPort)

--- a/Scripts/main.lua
+++ b/Scripts/main.lua
@@ -31,9 +31,20 @@ end
 ---@param message string|number
 ---@param ... any
 function LogOutput(severity, message, ...)
+  local args = { ... }
   if logLevel[severity] <= statics.ModLogLevel then
-    local msg = string.format(message, ...)
-    print(string.format("[%s] %s: %s\n", statics.ModName, severity, msg))
+    local status, err = pcall(function()
+      local msg = string.format(message, table.unpack(args))
+      local outMsg = string.format("[%s] %s: %s\n", statics.ModName, severity, msg)
+      if logLevel[severity] == 0 then
+        outMsg = outMsg .. debug.traceback() .. "\n"
+      end
+      print(outMsg)
+    end)
+    if not status then
+      print(string.format("[%s] WARN: LogOutput error while parsing: %s: %s\n%s\n", statics.ModName, message, err,
+      debug.traceback()))
+    end
   end
 end
 


### PR DESCRIPTION
* Logging error now outputs stack trace
* Fix `/status/traffic` endpoint error
* Replace hard-coded return value with `json.stringify()`