### PR TITLE
Create dedicated logging directory

### DIFF
--- a/.github/workflows/msvc_build.yml
+++ b/.github/workflows/msvc_build.yml
@@ -90,7 +90,7 @@ jobs:
           Copy-Item .\Binaries\Game__Shipping__Win64\MotorTownMods\MotorTownMods.dll .\output\MotorTownMods\dlls\main.dll
           Copy-Item -Recurse .\MotorTownMods\Scripts .\output\MotorTownMods\
           $staticsFile = Get-Content -Raw .\MotorTownMods\Scripts\Statics.lua
-          [regex]$versionRegex = 'ModVersion = "(.*)"'
+          [regex]$versionRegex = 'ModVersion = "(.*),?"'
           $modVersion = $versionRegex.Match($staticsFile).Groups[1].Value
           Compress-Archive -Path .\output\MotorTownMods ".\MotorTownMods_v${modVersion}.zip"
           Write-Output "version=$modVersion" >> $env:GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Most of the server settings can be configured using environment variables:
 | `MOD_MANAGEMENT_PORT`       | `5000`        | Management port. Used for managing mods in the dedicated server                                                            |
 | `MOD_SERVER_PORT`           | `5001`        | Lua HTTP port. This only applies if `luasocket` module is installed                                                        |
 | `MOD_SERVER_PROCESS_AMOUNT` | 5             | The amount of cumulative connection to process. Higher number correspond to quicker response, in return slower event hook. |
-| `MOD_SERVER_LOG_LEVEL`      | 2             | The server log level. `0=ERROR`, `1=WARNING`, `2=INFO`, `3=DEBUG`                                                          |
+| `MOD_SERVER_LOG_LEVEL`      | 2             | The server log level. `0=ERROR`, `1=WARNING`, `2=INFO`, `3=VERBOSE`, `4=DEBUG`                                             |
 | `MOD_WEBHOOK_URL`           | _none_        | Webhook URL to send the events to. Requires `luasec` to function                                                           |
 | `MOD_WEBHOOK_METHOD`        | `POST`        | Webhook request method                                                                                                     |
 | `MOD_WEBHOOK_EXTRA_HEADERS` | _none_        | Webhook extra headers in a JSON object                                                                                     |

--- a/Scripts/CargoManager.lua
+++ b/Scripts/CargoManager.lua
@@ -129,7 +129,6 @@ local function DeliveryToTable(delivery)
   data.SenderPoint = GuidToString(delivery.SenderPoint.DeliveryPointGuid)
   data.ReceiverPoint = GuidToString(delivery.ReceiverPoint.DeliveryPointGuid)
   data.RegisteredTimeSeconds = delivery.RegisteredTimeSeconds
-  data.ExpiresAtTimeSeconds = delivery.ExpiresAtTimeSeconds
   data.PaymentMultiplierByDemand = delivery.PaymentMultiplierByDemand
   data.PaymentMultiplierBySupply = delivery.PaymentMultiplierBySupply
   data.PaymentMultiplierByBalanceConfig = delivery.PaymentMultiplierByBalanceConfig

--- a/Scripts/Debugging/Logging.lua
+++ b/Scripts/Debugging/Logging.lua
@@ -1,0 +1,48 @@
+local statics = require("Statics")
+
+---@enum (key) LogLevel
+local logLevel = {
+    ERROR = 0,
+    WARN = 1,
+    INFO = 2,
+    VERBOSE = 3,
+    DEBUG = 4
+}
+
+---@deprecated Use LogOutput instead to avoid concat errors
+---Print a message to the console
+---@param message string
+---@param severity LogLevel?
+local function logMsg(message, severity)
+    local lvl = severity or "INFO"
+    if logLevel[lvl] > statics.ModLogLevel then return end
+    print(string.format("[%s] %s: %s\n", statics.ModName, lvl, message))
+end
+
+---Print a message to the console
+---Uses the `string.format()` under the hood to parse the message
+---@param severity LogLevel
+---@param message string|number
+---@param ... any
+local function logOutput(severity, message, ...)
+    local args = { ... }
+    if logLevel[severity] <= statics.ModLogLevel then
+        local status, err = pcall(function()
+            local msg = string.format(message, table.unpack(args))
+            local outMsg = string.format("[%s] %s: %s\n", statics.ModName, severity, msg)
+            if logLevel[severity] == 0 then
+                outMsg = outMsg .. debug.traceback() .. "\n"
+            end
+            print(outMsg)
+        end)
+        if not status then
+            print(string.format("[%s] WARN: LogOutput error while parsing: %s: %s\n%s\n", statics.ModName, message, err,
+                debug.traceback()))
+        end
+    end
+end
+
+return {
+    logMsg = logMsg,
+    logOutput = logOutput
+}

--- a/Scripts/Debugging/Timer.lua
+++ b/Scripts/Debugging/Timer.lua
@@ -1,0 +1,84 @@
+local statics = require("Statics")
+local socket = RequireSafe("socket") ---@type Socket?
+
+local enableTImer = statics.ModLogLevel > 2
+
+---@class DebugTimer
+---@field initTime number
+---@field timers number[]
+---@field label string?
+local debugTimer = {}
+debugTimer.__index = debugTimer
+
+---Create a new timer instance
+---@param label string?
+local function new(label)
+  local obj = setmetatable({}, debugTimer)
+  obj.initTime = 0
+  obj.label = label or "debugTimer"
+  obj.timers = {}
+  if enableTImer then
+    if socket then
+      obj.initTime = socket.gettime()
+    else
+      obj.initTime = os.clock()
+    end
+    table.insert(obj.timers, obj.initTime)
+  end
+  return obj
+end
+
+---Get delta time in seconds
+---@param checkpoint boolean? Reset the timer for another subsequent delta time
+function debugTimer.getDelta(self, checkpoint)
+  if enableTImer then
+    local delta = 0
+    local currentTime = 0
+    if socket then
+      currentTime = socket.gettime()
+      delta = currentTime - self.initTime
+    else
+      currentTime = os.clock()
+      delta = os.difftime(currentTime, self.initTime)
+    end
+    table.insert(self.timers, currentTime)
+    LogOutput("DEBUG", "%s[%i]: %fs", self.label, #self.timers - 1, delta)
+
+    if checkpoint then
+      if socket then
+        self.initTime = socket.gettime()
+      else
+        self.initTime = os.clock()
+      end
+    end
+  end
+end
+
+---Benchmark a function execution time
+---@param func function
+---@param ... any
+local function benchmark(func, ...)
+  local delta = 0
+  if enableTImer then
+    local initTime = 0
+    if socket then
+      initTime = socket.gettime()
+    else
+      initTime = os.clock()
+    end
+    local results = { func(...) }
+    if socket then
+      delta = socket.gettime() - initTime
+    else
+      delta = os.difftime(os.clock(), initTime)
+    end
+    return delta, table.unpack(results)
+  else
+    return delta, func(...)
+  end
+end
+
+return {
+  new = new,
+  benchmark = benchmark
+}

--- a/Scripts/Statics.lua
+++ b/Scripts/Statics.lua
@@ -1,4 +1,7 @@
+local outputLogLevel = tonumber(os.getenv("MOD_SERVER_LOG_LEVEL")) or 2
+
 return {
     ModName = "MotorTownMods",
-    ModVersion = "0.7.4"
+    ModVersion = "0.7.5",
+    ModLogLevel = outputLogLevel,
 }

--- a/Scripts/VehicleManager.lua
+++ b/Scripts/VehicleManager.lua
@@ -2,6 +2,7 @@ local webhook = require("Webclient")
 local json = require("JsonParser")
 local cargo = require("CargoManager")
 local assetManager = require("AssetManager")
+local timer = require("Debugging.Timer")
 
 local vehicleDealerSoftPath = "/Script/MotorTown.MTDealerVehicleSpawnPoint"
 
@@ -1636,13 +1637,16 @@ local function HandleGetVehicles(session)
     isPlayerControlled = true
   end
 
-  local res = GetVehicles(id, fields, limit, isPlayerControlled)
+  local getTime, data = timer.benchmark(GetVehicles, id, fields, limit, isPlayerControlled)
+  LogOutput("DEBUG", "GetVehicles time: %fs", getTime)
 
-  if id and #res == 0 then
+  if id and #data == 0 then
     return json.stringify { message = string.format("Vehicle with ID %s not found", id) }, nil, 404
   end
 
-  return json.stringify { data = res }, nil, 200
+  local stringifyTime, res = timer.benchmark(json.stringify, { data = data })
+  LogOutput("DEBUG", "GetVehicles stringify time: %fs", stringifyTime)
+  return res, nil, 200
 end
 
 ---Handle vehicle despawn request

--- a/Scripts/Webclient.lua
+++ b/Scripts/Webclient.lua
@@ -4,8 +4,7 @@ package.cpath = package.cpath .. ";" .. dir .. "/ue4ss/Mods/shared/?.dll"
 
 local json = require("JsonParser")
 local statics = require("Statics")
-local server = RequireSafe("Webserver")
-local socket = RequireSafe("socket")
+local socket = RequireSafe("socket") ---@type Socket?
 local http = RequireSafe("socket.http")
 local https = RequireSafe("ssl.https")
 local ltn12 = RequireSafe("ltn12")
@@ -97,7 +96,7 @@ end
 ---@param callback fun(status: boolean)? Optional callback after handling the request
 local function CreateEventWebhook(event, data, callback)
     LogOutput("DEBUG", "Received hook event %s", event)
-    if socket and webhookUrl and server then
+    if socket and webhookUrl then
         local payload = json.stringify {
             hook = event,
             timestamp = math.floor(socket.gettime() * 1000),

--- a/Scripts/Webserver.lua
+++ b/Scripts/Webserver.lua
@@ -16,6 +16,7 @@ local procAmount = tonumber(os.getenv("MOD_SERVER_PROCESS_AMOUNT")) or 5
 local usePartialSend = os.getenv("MOD_SERVER_SEND_PARTIAL")
 local bcrypt = RequireSafe("bcrypt")
 
+local enableDebug = statics.ModLogLevel > 2
 local port = tonumber(os.getenv("MOD_SERVER_PORT")) or 5001
 local isServerRunning = false
 local time = function()
@@ -335,6 +336,8 @@ end
 ---Dump headers for debugging
 ---@param client ClientTable
 local function dumpSession(client)
+    if not enableDebug then return end
+
     LogOutput("DEBUG", "==============================")
     LogOutput("DEBUG", "URL string: %s", client.urlString)
     LogOutput("DEBUG", "Method: %s", client.method)
@@ -357,9 +360,11 @@ local function dumpSession(client)
         end
     end
 
-    LogOutput("DEBUG", "URL Path: %s", client.urlComponents.path)
-    LogOutput("DEBUG", "URL Params: %s", client.urlComponents.params)
-    LogOutput("DEBUG", "URL url: %s", client.urlComponents.url)
+    if client.urlComponents then
+        LogOutput("DEBUG", "URL Path: %s", client.urlComponents.path or "")
+        LogOutput("DEBUG", "URL Params: %s", client.urlComponents.params or "")
+        LogOutput("DEBUG", "URL url: %s", client.urlComponents.url or "")
+    end
 
     LogOutput("DEBUG", "URL path components:")
     for k, v in pairs(client.pathComponents) do
@@ -367,7 +372,7 @@ local function dumpSession(client)
     end
 
     LogOutput("DEBUG", "Content Length: %d", client.contentLength)
-    LogOutput("DEBUG", "Content: %s", client.content)
+    LogOutput("DEBUG", "Content: %s", client.content or "")
     LogOutput("DEBUG", "==============================")
 end
 

--- a/Scripts/main.lua
+++ b/Scripts/main.lua
@@ -1,48 +1,10 @@
 require("Helpers")
-local statics = require("Statics")
 local json = require("JsonParser")
-local outputLogLevel = tonumber(os.getenv("MOD_SERVER_LOG_LEVEL")) or 2
-
----@enum (key) LogLevel
-local logLevel = {
-  ERROR = 0,
-  WARN = 1,
-  INFO = 2,
-  DEBUG = 3
-}
+local logging = require("Debugging.Logging")
 
 ---@deprecated Use LogOutput instead to avoid concat errors
----Print a message to the console
----@param message string
----@param severity LogLevel?
-function LogMsg(message, severity)
-  local lvl = severity or "INFO"
-  if logLevel[lvl] > outputLogLevel then return end
-  print(string.format("[%s] %s: %s\n", statics.ModName, lvl, message))
-end
-
----Print a message to the console
----Uses the `string.format()` under the hood to parse the message
----@param severity LogLevel
----@param message string|number
----@param ... any
-function LogOutput(severity, message, ...)
-  local args = { ... }
-  if logLevel[severity] <= outputLogLevel then
-    local status, err = pcall(function()
-      local msg = string.format(message, table.unpack(args))
-      local outMsg = string.format("[%s] %s: %s\n", statics.ModName, severity, msg)
-      if logLevel[severity] == 0 then
-        outMsg = outMsg .. debug.traceback() .. "\n"
-      end
-      print(outMsg)
-    end)
-    if not status then
-      print(string.format("[%s] WARN: LogOutput error while parsing: %s: %s\n%s\n", statics.ModName, message, err,
-        debug.traceback()))
-    end
-  end
-end
+LogMsg = logging.logMsg
+LogOutput = logging.logOutput
 
 local playerManager = require("PlayerManager")
 local eventManager = require("EventManager")


### PR DESCRIPTION
* `LogMsg` and `LogOutput` remains as global variable, but loaded from `Debugging.Logging` instead
* Add `Timer` for benchmarking functions
* Add verbose logging level
* Revert mod logging level in statics for reusability
* Fix cargo manager undefined fields
* Fix regex in build-core step