### PR TITLE
Fix post request without payload error

### DIFF
--- a/Scripts/JsonParser.lua
+++ b/Scripts/JsonParser.lua
@@ -200,7 +200,14 @@ function json.stringify(obj, as_key)
   return stringify_internal(obj, as_key)
 end
 
+---Parse string into lua value
+---@param str string
+---@param pos integer?
+---@param end_delim string?
+---@return unknown|nil
 function json.parse(str, pos, end_delim)
+  if str == nil then return nil end
+
   if cjson then
     local status, output = pcall(cjson.decode, str)
     if status then return output end

--- a/Scripts/Statics.lua
+++ b/Scripts/Statics.lua
@@ -2,6 +2,6 @@ local outputLogLevel = tonumber(os.getenv("MOD_SERVER_LOG_LEVEL")) or 2
 
 return {
     ModName = "MotorTownMods",
-    ModVersion = "0.8.1",
+    ModVersion = "0.8.2",
     ModLogLevel = outputLogLevel,
 }


### PR DESCRIPTION
Any post request with required payload will fail if no payload is provided.