### PR TITLE
Add vehicle parameter modification endpoint

### DIFF
--- a/Scripts/Statics.lua
+++ b/Scripts/Statics.lua
@@ -2,6 +2,6 @@ local outputLogLevel = tonumber(os.getenv("MOD_SERVER_LOG_LEVEL")) or 2
 
 return {
     ModName = "MotorTownMods",
-    ModVersion = "0.8.5",
+    ModVersion = "0.8.6",
     ModLogLevel = outputLogLevel,
 }

--- a/Scripts/Webserver.lua
+++ b/Scripts/Webserver.lua
@@ -25,7 +25,8 @@ local _method = {
     GET = "GET",
     POST = "POST",
     PUT = "PUT",
-    DELETE = "DELETE"
+    DELETE = "DELETE",
+    PATCH = "PATCH",
 }
 
 ---@enum (key) ConnectionState

--- a/Scripts/main.lua
+++ b/Scripts/main.lua
@@ -64,8 +64,10 @@ local function LoadWebserver()
 
     -- Vehicle management
     server.registerHandler("/vehicles", "GET", vehicleManager.HandleGetVehicles)
+    server.registerHandler("/vehicles", "PATCH", vehicleManager.HandleSetVehicleParameter)
     server.registerHandler("/vehicles/*/despawn", "POST", vehicleManager.HandleDespawnVehicle)
     server.registerHandler("/vehicles/*", "GET", vehicleManager.HandleGetVehicles)
+    server.registerHandler("/vehicles/*", "PATCH", vehicleManager.HandleSetVehicleParameter)
     server.registerHandler("/dealers/spawn", "POST", vehicleManager.HandleCreateVehicleDealerSpawnPoint)
     server.registerHandler("/garages", "GET", vehicleManager.HandleGetGarages)
     server.registerHandler("/garages/spawn", "POST", vehicleManager.HandleGetGarages)

--- a/docs/LuaHttpServer/VehicleManagement.md
+++ b/docs/LuaHttpServer/VehicleManagement.md
@@ -934,13 +934,43 @@ Get all currently available vehicles in game. This is a very resource intensive 
 
 </details>
 
-#### GET `/vehicles/<guid>`
+#### PATCH `/vehicles`
 
-Get selected vehicle guid. This is currently only works for player owned vehicles as NPC vehicles are marked with -1 guid. Retuns the same response and using the same query as above.
+Patch a vehicle parameter based on the player unique ID.
 
-#### POST `/vehicles/<guid>/despawn`
+<details>
+<summary>Request body:</summary>
 
-Despawn selected vehicle with the given guid. This is currently only works for player owned vehicles as NPC vehicles are marked with -1 guid. Returns a `204` for a successful request.
+```json
+{
+  "PlayerId": "",
+  "Field": "NetLC_VehicleState.Fuel",
+  "Value": 10
+}
+```
+
+</details>
+
+<details>
+<summary>Response data:</summary>
+
+```json
+{ "status": "ok" }
+```
+
+</details>
+
+#### GET `/vehicles/<id>`
+
+Get selected vehicle ID. This is currently only works for player owned vehicles as NPC vehicles are marked with negative integers. Retuns the same response and using the same query as [`GET /vehicles`](#get-vehicles).
+
+#### PATCH `/vehicles/<id>`
+
+Patch a vehicle parameter based on the vehicle ID. Uses the same request body and return response as [`PATCH /vehicles`](#patch-vehicles) without the `PlayerId` field.
+
+#### POST `/vehicles/<id>/despawn`
+
+Despawn selected vehicle with the given ID. This is currently only works for player owned vehicles as NPC vehicles are marked with negative integers. Returns a `204` for a successful request.
 
 #### POST `/dealers/spawn`
 


### PR DESCRIPTION
Modify a vehicle based on its ID or by the vehicle currently operated by a player. This operation might cause a server crash if not supplied with the correct field and value.