### PR TITLE
Move function execution to GameThread

### DIFF
--- a/Scripts/ChatManager.lua
+++ b/Scripts/ChatManager.lua
@@ -29,11 +29,13 @@ local function AnnounceServerMessage(message, playerId, pinned)
   if PC:IsValid() then
     ---@cast PC AMotorTownPlayerController
 
-    if pinned then
-      PC:ServerAnnouncePinned(message)
-    else
-      PC:ServerAnnounce(message)
-    end
+    ExecuteInGameThread(function()
+      if pinned then
+        PC:ServerAnnouncePinned(message)
+      else
+        PC:ServerAnnounce(message)
+      end
+    end)
     local id = GetPlayerUniqueId(PC)
     return true, id
   elseif pinned then

--- a/Scripts/EventManager.lua
+++ b/Scripts/EventManager.lua
@@ -251,16 +251,19 @@ local function ChangeEventState(eventGuid, state)
             return false
           end
 
-          -- RPC call doesn't support StructProperty, so were using table instead
-          PC:ServerChangeEventState(
-            {
-              A = event.EventGuid.A,
-              B = event.EventGuid.B,
-              C = event.EventGuid.C,
-              D = event.EventGuid.D
-            },
-            state
-          )
+          ExecuteInGameThread(function()
+            -- RPC call doesn't support StructProperty, so were using table instead
+            PC:ServerChangeEventState(
+              {
+                A = event.EventGuid.A,
+                B = event.EventGuid.B,
+                C = event.EventGuid.C,
+                D = event.EventGuid.D
+              },
+              state
+            )
+          end)
+
           return true
         end
       end
@@ -285,15 +288,17 @@ local function RemoveEvent(eventGuid)
         local event = gameState.Net_EventSystem.Net_Events[i]
 
         if GuidToString(event.EventGuid) == eventGuid then
-          -- RPC call doesn't support StructProperty, so were using table instead
-          PC:ServerRemoveEvent(
-            {
-              A = event.EventGuid.A,
-              B = event.EventGuid.B,
-              C = event.EventGuid.C,
-              D = event.EventGuid.D
-            }
-          )
+          ExecuteInGameThread(function()
+            -- RPC call doesn't support StructProperty, so were using table instead
+            PC:ServerRemoveEvent(
+              {
+                A = event.EventGuid.A,
+                B = event.EventGuid.B,
+                C = event.EventGuid.C,
+                D = event.EventGuid.D
+              }
+            )
+          end)
           return true
         end
       end

--- a/Scripts/Statics.lua
+++ b/Scripts/Statics.lua
@@ -2,6 +2,6 @@ local outputLogLevel = tonumber(os.getenv("MOD_SERVER_LOG_LEVEL")) or 2
 
 return {
     ModName = "MotorTownMods",
-    ModVersion = "0.8.6",
+    ModVersion = "0.8.7",
     ModLogLevel = outputLogLevel,
 }

--- a/Scripts/VehicleManager.lua
+++ b/Scripts/VehicleManager.lua
@@ -1499,7 +1499,9 @@ local function DespawnVehicleById(id, uniqueId)
 
       if PC:IsValid() and playerState.bIsAdmin then
         if playerState.bIsHost then
-          PC:ServerDespawnVehicle(vehicle, 0)
+          ExecuteInGameThread(function()
+            PC:ServerDespawnVehicle(vehicle, 0)
+          end)
           return true
         else
           return webhook.CreateServerRequest(

--- a/Scripts/ViewportManager.lua
+++ b/Scripts/ViewportManager.lua
@@ -91,7 +91,7 @@ local function SetWidgetVisibility(widget, inverse)
       table.insert(inGameWidgets, hudWidget.PlayerList)
     end
 
-    for index, value in ipairs(inGameWidgets) do
+    for _, value in ipairs(inGameWidgets) do
       if value:IsValid() then
         LogOutput("DEBUG", "Setting %s visibility to %q", value:GetFullName(), isVisible)
         if useOpacity then
@@ -114,7 +114,7 @@ local function ShowMessagePopup(message, uniqueId)
     if type(uniqueId) == "string" then
       table.insert(playerControllers, GetPlayerControllerFromUniqueId(uniqueId))
     elseif type(uniqueId) == "table" then
-      for index, value in ipairs(uniqueId) do
+      for _, value in ipairs(uniqueId) do
         table.insert(playerControllers, GetPlayerControllerFromUniqueId(value))
       end
     end
@@ -128,13 +128,15 @@ local function ShowMessagePopup(message, uniqueId)
     end
   end
 
-  for index, value in ipairs(playerControllers) do
-    if value:IsValid() then
-      ---@cast value AMotorTownPlayerController
+  ExecuteInGameThread(function()
+    for _, value in ipairs(playerControllers) do
+      if value:IsValid() then
+        ---@cast value AMotorTownPlayerController
 
-      value:ClientShowPopupMessage(FText(message))
+        value:ClientShowPopupMessage(FText(message))
+      end
     end
-  end
+  end)
 end
 
 ---Set hot bar position


### PR DESCRIPTION
Game is reportedly crashing whenever a player function is called. Which probably caused by threading. Moving it to `GameThread` should fix this issue. The downside is there will be no immediate response as the `ExecuteInGameThread` is latent without any callback.