### PR TITLE
Remove Gameplay Ability System stack

### DIFF
--- a/Scripts/PlayerManager.lua
+++ b/Scripts/PlayerManager.lua
@@ -143,8 +143,40 @@ local function HandleTeleportPlayer(session)
   return json.stringify { error = "Invalid payload" }, nil, 400
 end
 
+---Handle removing given amount from gameplay effect stack
+---@type RequestPathHandler
+local function HandleRemoveGameplayEffect(session)
+  local playerId = session.pathComponents[2]
+  local data = json.parse(session.content)
+  local amount = math.floor(tonumber(data and data.Amount) or 1)
+
+  if data and playerId then
+    local PC = GetPlayerControllerFromUniqueId(playerId)
+    if PC:IsValid() then
+      local PS = PC.PlayerState
+
+      if PS:IsValid() then
+        ---@cast PS AMotorTownPlayerState
+
+        if PS.Character:IsValid() then
+          local comp = PS.Character.AbilityComponent
+
+          if comp:RemoveActiveGameplayEffect({}, amount) then
+            return json.stringify { message = "Successfully removed gameplay effect" }
+          else
+            return json.stringify { error = "Failed to remove active gameplay effect" }, nil, 400
+          end
+        end
+      end
+    end
+  end
+
+  return json.stringify { error = "invalid payload" }, nil, 400
+end
+
 return {
   HandleGetPlayerStates = HandleGetPlayerStates,
   GetMyCurrentTransform = GetMyCurrentTransform,
   HandleTeleportPlayer = HandleTeleportPlayer,
+  HandleRemoveGameplayEffect = HandleRemoveGameplayEffect,
 }

--- a/Scripts/main.lua
+++ b/Scripts/main.lua
@@ -45,7 +45,7 @@ local function LoadWebserver()
     -- Player management
     server.registerHandler("/players", "GET", playerManager.HandleGetPlayerStates)
     server.registerHandler("/players/*/teleport", "POST", playerManager.HandleTeleportPlayer)
-    server.registerHandler("/players/*/gameplay/effect", "DELETE", playerManager.HandleRemoveGameplayEffect)
+    server.registerHandler("/players/*/gameplay/effects", "DELETE", playerManager.HandleRemoveGameplayEffect)
     server.registerHandler("/players/*", "GET", playerManager.HandleGetPlayerStates)
 
     -- Event management

--- a/Scripts/main.lua
+++ b/Scripts/main.lua
@@ -45,6 +45,7 @@ local function LoadWebserver()
     -- Player management
     server.registerHandler("/players", "GET", playerManager.HandleGetPlayerStates)
     server.registerHandler("/players/*/teleport", "POST", playerManager.HandleTeleportPlayer)
+    server.registerHandler("/players/*/gameplay/effect", "DELETE", playerManager.HandleRemoveGameplayEffect)
     server.registerHandler("/players/*", "GET", playerManager.HandleGetPlayerStates)
 
     -- Event management

--- a/docs/LuaHttpServer/PlayerManagement.md
+++ b/docs/LuaHttpServer/PlayerManagement.md
@@ -78,3 +78,29 @@ Teleport a player pawn to the desired location and optionally its rotation.
 ```
 
 </details>
+
+#### DELETE `/players/<uniqueId>/gameplay/effects`
+
+Remove a specific amount from the gameplay effect stack. Useful for removing GAS related effect without specifying the tag. Currently only used for removing `Police.Suspect` effect.
+
+<details>
+<summary>Request body:</summary>
+
+```json
+{
+  "Amount": 1 // Optional amount. Defaults to 1.
+}
+```
+
+</details>
+
+<details>
+<summary>Response data:</summary>
+
+```json
+{
+  "message": "Successfully removed gameplay effect"
+}
+```
+
+</details>


### PR DESCRIPTION
Remove a specific amount from the gameplay effect stack. Useful for removing GAS related effect without specifying the tag. Currently only used for removing `Police.Suspect` effect.