### PR TITLE
Add company related endpoints & webhooks

### DIFF
--- a/.github/workflows/msvc_build.yml
+++ b/.github/workflows/msvc_build.yml
@@ -13,9 +13,6 @@ permissions:
 jobs:
   build-core:
     runs-on: windows-2022
-    outputs:
-      version: ${{ steps.package-build.outputs.version }}
-      majorMinorVersion: ${{ steps.package-build.outputs.majorMinorVersion }}
 
     steps:
       - name: Checkout working repository
@@ -69,27 +66,15 @@ jobs:
         id: package-build
         shell: pwsh
         run: |
-          $tag = "${{ github.ref_name }}"
-          if ($tag.StartsWith("v")) { $modVersion = $tag.Substring(1) } else { $modVersion = $tag }
-
-          [regex]$majorMinorRegex = '^([0-9]+\.[0-9]+)'
-          $majorMinorVersion = $majorMinorRegex.Match($modVersion).Groups[1].Value
-
           New-Item -ItemType Directory -Force .\output\MotorTownMods\dlls
           New-Item -ItemType File .\output\MotorTownMods\enabled.txt
           Copy-Item .\Binaries\Game__Shipping__Win64\MotorTownMods\MotorTownMods.dll .\output\MotorTownMods\dlls\main.dll
           Copy-Item -Recurse .\MotorTownMods\Scripts .\output\MotorTownMods\
 
           $staticsFilePath = ".\output\MotorTownMods\Scripts\Statics.lua"
-          (Get-Content $staticsFilePath) -replace '(ModVersion\s*=\s*").*(")', ('${1}' + $modVersion + '${2}') | Set-Content $staticsFilePath
+          (Get-Content $staticsFilePath) -replace '(ModVersion\s*=\s*").*(")', ('${1}' + "${{ github.ref_name }}" + '${2}') | Set-Content $staticsFilePath
 
-          Compress-Archive -Path .\output\MotorTownMods ".\MotorTownMods_v${modVersion}.zip"
-
-          Write-Output "version=$modVersion" >> $env:GITHUB_OUTPUT
-          Write-Output "majorMinorVersion=$majorMinorVersion" >> $env:GITHUB_OUTPUT
-
-          (Get-Content -Path $env:GITHUB_EVENT_PATH | ConvertFrom-Json).head_commit.message > commit_msg.txt
-          Get-Content commit_msg.txt | select -skip 2 > release_description.md
+          Compress-Archive -Path .\output\MotorTownMods ".\MotorTownMods_${{ github.ref_name }}.zip"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -212,10 +197,16 @@ jobs:
           path: shared.zip
           overwrite: true
 
-  check-latest:
+  create-release:
+    needs:
+      - build-core
+      - build-deps
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     outputs:
-      is-latest: ${{ steps.compare-tags.outputs.is-latest }}
+      is-latest: ${{ steps.get-version.outputs.is-latest }}
+      version: ${{ steps.get-version.outputs.version }}
 
     steps:
       - name: Get latest tag
@@ -225,9 +216,13 @@ jobs:
           repository: drpsyko101/MotorTownMods
           releases-only: true
 
-      - name: Compare tags
-        id: compare-tags
-        run: | # Compare tag wth latest tag
+      - name: Get major.minor version
+        id: get-version
+        run: |
+          echo "version=${{ github.ref_name }}" | sed -E 's/v([0-9]+)\.([0-9]+).*/\1.\2/g' >> $GITHUB_OUTPUT
+
+          jq -r .head_commit.message $GITHUB_EVENT_PATH | sed 1,2d > release_description.md
+
           latest_tag="${{ steps.latest-tag.outputs.tag }}"
           current_tag="${{ github.ref_name }}"
 
@@ -241,16 +236,6 @@ jobs:
             echo "is-latest=false" >> $GITHUB_OUTPUT 
           fi
 
-  create-release:
-    needs:
-      - build-core
-      - build-deps
-      - check-latest
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-
-    steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -262,14 +247,39 @@ jobs:
         continue-on-error: true
         with:
           token: ${{ github.token }}
-          tag: v${{ needs.build-core.outputs.majorMinorVersion }}
+          tag: v${{ steps.get-version.outputs.version }}
           assets: "*"
 
       - name: Create/update release
         uses: softprops/action-gh-release@v2
         with:
-          name: MotorTownMods v${{ needs.build-core.outputs.version }}
-          tag_name: v${{ needs.build-core.outputs.majorMinorVersion }}
+          name: MotorTownMods ${{ github.ref_name }}
+          tag_name: v${{ steps.get-version.outputs.version }}
           body_path: release_description.md
           files: "**/*.zip"
-          make_latest: ${{ needs.check-latest.outputs.is-latest }}
+          make_latest: ${{ steps.get-version.outputs.is-latest }}
+
+  repo-cleanup:
+    needs:
+      - create-release
+    if: needs.create-release.outputs.is-latest == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ needs.create-release.outputs.version }}
+          tag_prefix: v
+
+      - name: Remove patch tag
+        run: |
+          git tag -d ${{ github.ref_name }}
+          git push -d origin ${{ github.ref_name }}

--- a/Scripts/AssetManager.lua
+++ b/Scripts/AssetManager.lua
@@ -1,6 +1,5 @@
 local UEHelpers = require("UEHelpers")
 local json = require("JsonParser")
-local socket = require("socket")
 
 ---Spawn an actor at the desired place
 ---@param assetPath string
@@ -19,10 +18,9 @@ local function SpawnActor(assetPath, location, rotation, tag)
     ---@cast staticMeshClass UClass
     local actor = CreateInvalidObject() ---@cast actor AActor
     local object = StaticFindObject(assetPath)
-    local isProcessing = true
 
     local assetTag = tag
-    ExecuteInGameThread(function()
+    ExecuteInGameThreadSync(function()
       pcall(function()
         LoadAsset(assetPath)
         local assetClass = {}
@@ -53,11 +51,7 @@ local function SpawnActor(assetPath, location, rotation, tag)
           }
         )
       end)
-      isProcessing = false
     end)
-    while isProcessing do
-      socket.sleep(0.01)
-    end
     if actor:IsValid() then
       LogOutput("DEBUG", "Spawned actor %s", actor:GetFullName())
 

--- a/Scripts/CompanyManager.lua
+++ b/Scripts/CompanyManager.lua
@@ -1,25 +1,94 @@
 local json = require("JsonParser")
+local webhook = require("Webclient")
 
 ---Get all companies or selected company by given GUID
 ---@param id string?
----@param filter string[]?
----@param limit integer?
-local function GetCompanies(id, filter, limit)
+---@param depth integer?
+local function GetCompanies(id, depth)
   local gameState = GetMotorTownGameState()
   if gameState:IsValid() then
     local comp = gameState.Net_CompanySystem
     if comp:IsValid() then
-      if filter then
-        local data = {}
-        for _, value in ipairs(filter) do
-          MergeTables(data, GetObjectAsTable(gameState.Net_CompanySystem, value, "MTCompanySystem"))
+      local companies = GetObjectAsTable(gameState.Net_CompanySystem, "Server_Companies", "MTCompanySystem", depth)
+
+      if id then
+        for _, company in ipairs(companies) do
+          if company.Guid == id then
+            return company
+          end
         end
+      else
+        return companies
       end
-      return GetObjectAsTable(gameState.Net_CompanySystem, nil, "MTCompanySystem")
     end
   end
   return {}
 end
+
+-- Register event callbacks
+
+webhook.RegisterEventHook("ServerCreateCompany", function(context, CompanyName, bIsCorporation, Money)
+  local PC = context:get() ---@type AMotorTownPlayerController
+  local name = CompanyName:get() ---@type FString
+  local isCorp = bIsCorporation:get() ---@type boolean
+  local money = Money:get() ---@type integer
+
+  LogOutput("DEBUG", "A new %s %s is created", bIsCorporation and "corporation" or "company", name:ToString())
+
+  return {
+    PlayerId = GetPlayerUniqueId(PC),
+    CompanyName = name:ToString(),
+    bIsCorporation = isCorp,
+    Money = money,
+  }
+end)
+
+webhook.RegisterEventHook("ServerCloseDownCompany", function(context, CompanyGuid)
+  local PC = context:get() ---@type AMotorTownPlayerController
+  local guid = GuidToString(CompanyGuid:get())
+
+  local company = GetCompanies(guid)
+
+  LogOutput("DEBUG", "A company/corporation %s has closed down", guid)
+
+  return {
+    PlayerId = GetPlayerUniqueId(PC),
+    CompanyGuid = guid,
+  }
+end)
+
+webhook.RegisterEventHook("ServerRequestJoinCompany", function(context, CompanyGuid)
+  local PC = context:get() ---@type AMotorTownPlayerController
+  local guid = GuidToString(CompanyGuid:get())
+  local playerId = GetPlayerUniqueId(PC)
+
+  LogOutput("DEBUG", "Player %s requested to join company/corporation %s", playerId, guid)
+
+  return {
+    PlayerId = playerId,
+    CompanyGuid = guid,
+  }
+end)
+
+webhook.RegisterEventHook("ServerDenyCompanyJoinRequest", function(context, CompanyGuid, JoinRequest)
+  local PC = context:get() ---@type AMotorTownPlayerController
+  local guid = GuidToString(CompanyGuid:get())
+  local req = JoinRequest:get() ---@type FMTCompanyJoinRequest
+
+  LogOutput("DEBUG", "Player %s denied to join company %s", req.CharacterId.UniqueNetId:ToString(), guid)
+
+  return {
+    PlayerId = GetPlayerUniqueId(PC),
+    CompanyGuid = guid,
+    JoinRequest = {
+      CharacterId = {
+        CharacterGuid = GuidToString(req.CharacterId.CharacterGuid),
+        UniqueNetId = req.CharacterId.UniqueNetId:ToString(),
+      },
+      CharacterName = req.CharacterName:ToString()
+    }
+  }
+end)
 
 -- Handle HTTP requests
 
@@ -27,10 +96,9 @@ end
 ---@type RequestPathHandler
 local function HandleGetCompanies(session)
   local companyGuid = session.pathComponents[2]
-  local filters = SplitString(session.queryComponents.filters)
-  local limit = tonumber(session.queryComponents.limit)
+  local depth = tonumber(session.queryComponents.depth)
 
-  local company = GetCompanies(companyGuid, filters, limit)
+  local company = GetCompanies(companyGuid, depth)
 
   if companyGuid and #company == 0 then
     return json.stringify { message = string.format("Company with %s GUID not found", companyGuid) }, nil, 404
@@ -39,6 +107,42 @@ local function HandleGetCompanies(session)
   return json.stringify { data = company }
 end
 
+---Handle get company depots request
+---@type RequestPathHandler
+local function HandleGetCompanyDepots(session)
+  local guid = session.pathComponents[2]
+  local buildingGuid = session.pathComponents[4]
+  local depth = tonumber(session.queryComponents.depth)
+
+  local gameState = GetMotorTownGameState()
+  if gameState:IsValid() then
+    local comp = gameState.Net_CompanySystem
+    if comp:IsValid() then
+      local depots = GetObjectAsTable(comp, "Net_Depots", nil, depth)
+      local data = {}
+
+      for _, depot in ipairs(depots) do
+        if depot.CompanyGuid == guid then
+          if buildingGuid and buildingGuid == depot.BuildingGuid then
+            return json.stringify { data = depot }
+          end
+
+          table.insert(data, depot)
+        end
+      end
+
+      if buildingGuid then
+        local msg = string.format("Building %s for company %s not found", buildingGuid, guid)
+        return json.stringify { error = msg }, nil, 404
+      end
+
+      return json.stringify { data = data }
+    end
+  end
+  error("Invalid game state/company system")
+end
+
 return {
-  HandleGetCompanies = HandleGetCompanies
+  HandleGetCompanies = HandleGetCompanies,
+  HandleGetCompanyDepots = HandleGetCompanyDepots,
 }

--- a/Scripts/EventManager.lua
+++ b/Scripts/EventManager.lua
@@ -171,19 +171,9 @@ local function CreateNewEvent(event)
       end
 
       -- Execute new event creation in game thread synchronously
-      local isProcessing = true
-      ExecuteInGameThread(function()
+      ExecuteInGameThreadSync(function()
         PC:ServerAddEvent(newEvent)
-        isProcessing = false
       end)
-
-      while isProcessing do
-        if socket then
-          socket.sleep(0.01)
-        else
-          Sleep(10)
-        end
-      end
     else
       error("Invalid playerId provided")
     end

--- a/Scripts/Webclient.lua
+++ b/Scripts/Webclient.lua
@@ -20,6 +20,10 @@ local events = {
     ServerJoinEvent = "/Script/MotorTown.MotorTownPlayerController:ServerJoinEvent",
     ServerLeaveEvent = "/Script/MotorTown.MotorTownPlayerController:ServerLeaveEvent",
     ServerCargoArrived = "/Script/MotorTown.MotorTownPlayerController:ServerCargoArrived",
+    ServerCreateCompany = "/Script/MotorTown.MotorTownPlayerController:ServerCreateCompany",
+    ServerCloseDownCompany = "/Script/MotorTown.MotorTownPlayerController:ServerCloseDownCompany",
+    ServerRequestJoinCompany = "/Script/MotorTown.MotorTownPlayerController:ServerRequestJoinCompany",
+    ServerDenyCompanyJoinRequest = "/Script/MotorTown.MotorTownPlayerController:ServerDenyCompanyJoinRequest",
 }
 
 ---Send a request to the specified URL
@@ -187,7 +191,7 @@ end
 
 ---Register event hook wrapper
 ---@param event EventHook
----@param hookFunction fun(self: UObject, ...): table|table[]|nil
+---@param hookFunction fun(self: UObject, ...): table|table[]
 ---@param callback fun(status: boolean)?
 ---@return integer? preId
 ---@return integer? postId
@@ -198,8 +202,10 @@ local function RegisterEventHook(event, hookFunction, callback)
             local preId, postId = RegisterHook(eventName, function(self, ...)
                 local status, result = pcall(hookFunction, self, ...)
                 if status then
-                    if result then
+                    if result and type(result) == "table" then
                         CreateEventWebhook(eventName, result, callback)
+                    else
+                        error("Invalid return value specified")
                     end
                 else
                     LogOutput("ERROR", "Failed to execute event hook: %s", result)

--- a/Scripts/main.lua
+++ b/Scripts/main.lua
@@ -89,6 +89,8 @@ local function LoadWebserver()
 
     -- Company management
     server.registerHandler("/companies", "GET", companyManager.HandleGetCompanies)
+    server.registerHandler("/companies/*/depots", "GET", companyManager.HandleGetCompanyDepots)
+    server.registerHandler("/companies/*/depots/*", "GET", companyManager.HandleGetCompanyDepots)
 
     -- Character management
     server.registerHandler("/characters", "GET", characterManager.HandleGetCharacters)


### PR DESCRIPTION
* Set `GET /companies` will actually return just companies, instead of needing to specify the filter
* Add `GET /companies/*/depots` list the company-owned depots
* Add `GET /companies/*/depots/*` list specific company-owned depot
* Fix `POST /players/<id>/teleport` not actually teleport player
* Add tag cleanup workflow
* Add `ServerCreateCompany`, `ServerCloseDownCompany`, `ServerRequestJoinCompany` & `ServerDenyCompanyJoinRequest` webhook