### PR TITLE
Fix ServerCargoArrived webhook returning empty cargo

### DIFF
--- a/Scripts/CargoManager.lua
+++ b/Scripts/CargoManager.lua
@@ -96,7 +96,7 @@ webhook.RegisterEventHook(
     local playerId = GetPlayerUniqueId(context:get())
     local data = {}
     Cargos:get():ForEach(function(key, value)
-      table.insert(data, GetObjectAsTable(value:get()))
+      table.insert(data, GetObjectAsTable(value:get(), nil, "MTCargo"))
     end)
     return {
       PlayerId = playerId,


### PR DESCRIPTION
Turns out it is returning the wrong subclass property. Fixed by specifying the class name in the `GetObjectAsTable`.