### PR TITLE
Fix garage not being visible to players

### DIFF
--- a/Scripts/VehicleManager.lua
+++ b/Scripts/VehicleManager.lua
@@ -152,6 +152,8 @@ local function SpawnGarage(location, rotation)
   ---@cast garageClass UClass
 
   if status and actor and actor:IsValid() and actor:IsA(garageClass) then
+    ---@cast actor AMTGarageActor
+    actor:SetReplicates(true)
     return true, assetTag
   end
   return false


### PR DESCRIPTION
Previously, the spawned garage was not visible to players. Setting it to replicate fixes that issue.