### PR TITLE
Fix add money crash

### DIFF
--- a/Scripts/PlayerManager.lua
+++ b/Scripts/PlayerManager.lua
@@ -234,10 +234,13 @@ local function HandleAddMoney(session)
     local amount = math.floor(tonumber(data.Amount) or 0)
     local message = data.Message or ""
     local PC = GetPlayerControllerFromUniqueId(playerId)
+    local allowNegative = data.AllowNegative or false
 
     if PC:IsValid() then
       ---@cast PC AMotorTownPlayerController
-      PC:ClientAddMoney(amount, "", FText(message), false, "", "")
+      ExecuteInGameThreadSync(function()
+        PC:ClientAddMoney(amount, "", FText(message), allowNegative, "", "")
+      end)
       return json.stringify { message = string.format("Added %d money to player %s", amount, playerId) }
     end
   end

--- a/docs/LuaHttpServer/PlayerManagement.md
+++ b/docs/LuaHttpServer/PlayerManagement.md
@@ -90,7 +90,8 @@ Add a specific amount of money to a player.
 ```json
 {
   "Amount": 1000, // Optional amount. Defaults to 0.
-  "Message": "Here is some money" // Optional message to be displayed.
+  "Message": "Here is some money", // Optional message to be displayed.
+  "AllowNegative": false // Allow player to go into debt
 }
 ```
 


### PR DESCRIPTION
Crashes observed while trying to add/deduct money from the player using the API. Executing the command in the game thread should fix this issue.