### PR TITLE
Fix some asset not visible to players

### DIFF
--- a/Scripts/VehicleManager.lua
+++ b/Scripts/VehicleManager.lua
@@ -148,12 +148,8 @@ end
 ---@param rotation FRotator
 local function SpawnGarage(location, rotation)
   local status, assetTag, actor = assetManager.SpawnActor(garageSoftPath, location, rotation)
-  local garageClass = StaticFindObject("/Script/MotorTown.MTGarageActor")
-  ---@cast garageClass UClass
 
-  if status and actor and actor:IsValid() and actor:IsA(garageClass) then
-    ---@cast actor AMTGarageActor
-    actor:SetReplicates(true)
+  if status and actor and actor:IsValid() then
     return true, assetTag
   end
   return false


### PR DESCRIPTION
Some objects are not set to replicate by default. This PR fixes the issue by setting the spawned actors to replicate on spawn. This still doesn't solve the draw distance for static mesh assets though.