### PR TITLE
Fix invisible spawned static mesh

### DIFF
--- a/.github/workflows/msvc_build.yml
+++ b/.github/workflows/msvc_build.yml
@@ -308,6 +308,5 @@ jobs:
           git push -f origin ${{ needs.create-release.outputs.majorminor-version }}
 
       - name: Delete current branch
-        if: ! contains(github.event.head_commit.message , '#block_deletion')
         run: |
           git push -d origin ${{ github.ref_name }}


### PR DESCRIPTION
The static mesh spawned by the server is not visible to clients. Turns out, the `StaticMeshComponent` must also be set to replicate.